### PR TITLE
Fix When ViewController whose view is not in the window hierarchy , present Scan ViewController will failed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 4.0.1
-Fix When ViewController whose view is not in the window hierarchy , present Scan ViewController failed will failed.
+- Fix When ViewController whose view is not in the window hierarchy , present Scan ViewController failed will failed.
 
 ## 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.1
+Fix When ViewController whose view is not in the window hierarchy , present Scan ViewController failed will failed.
+
 ## 4.0.0
 
 - Original [barcode_scan](https://pub.dev/packages/barcode_scan) was discontinued, so [barcode_scan2](https://pub.dev/packages/barcode_scan) was borned with sound null safety support🎉

--- a/ios/Classes/SwiftBarcodeScanPlugin.swift
+++ b/ios/Classes/SwiftBarcodeScanPlugin.swift
@@ -11,7 +11,7 @@ public class SwiftBarcodeScanPlugin: NSObject, FlutterPlugin, BarcodeScannerView
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "de.mintware.barcode_scan", binaryMessenger: registrar.messenger())
         let instance = SwiftBarcodeScanPlugin()
-        instance.hostViewController = UIApplication.shared.delegate?.window??.rootViewController
+        instance.hostViewController = topViewController()
         registrar.addMethodCallDelegate(instance, channel: channel)
     }
     
@@ -68,6 +68,19 @@ public class SwiftBarcodeScanPlugin: NSObject, FlutterPlugin, BarcodeScannerView
     
     func didFailWithErrorCode(_ controller: BarcodeScannerViewController?, errorCode: String) {
         result?(FlutterError(code: errorCode, message: nil, details: nil))
+    }
+    
+    private class func topViewController(base: UIViewController? = UIApplication.shared.keyWindow?.rootViewController) -> UIViewController? {
+        if let nav = base as? UINavigationController {
+            return topViewController(base: nav.visibleViewController)
+
+        } else if let tab = base as? UITabBarController, let selected = tab.selectedViewController {
+            return topViewController(base: selected)
+
+        } else if let presented = base?.presentedViewController {
+            return topViewController(base: presented)
+        }
+        return base
     }
 }
 


### PR DESCRIPTION
FIX when present scan ViewController failed because Attempt to present UINavigationController whose view is not in the window hierarchy