### PR TITLE
Fix After flutter plugin register, the topViewController may changed …

### DIFF
--- a/ios/Classes/SwiftBarcodeScanPlugin.swift
+++ b/ios/Classes/SwiftBarcodeScanPlugin.swift
@@ -11,7 +11,6 @@ public class SwiftBarcodeScanPlugin: NSObject, FlutterPlugin, BarcodeScannerView
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "de.mintware.barcode_scan", binaryMessenger: registrar.messenger())
         let instance = SwiftBarcodeScanPlugin()
-        instance.hostViewController = topViewController()
         registrar.addMethodCallDelegate(instance, channel: channel)
     }
     
@@ -30,6 +29,13 @@ public class SwiftBarcodeScanPlugin: NSObject, FlutterPlugin, BarcodeScannerView
     }
     
     private func showBarcodeView(config: Configuration? = nil) {
+    
+				if let rootVC = UIApplication.shared.keyWindow?.rootViewController {
+            hostViewController = topViewController(base:rootVC)
+        } else if let window = UIApplication.shared.delegate?.window,let rootVC = window?.rootViewController {
+            hostViewController = topViewController(base:rootVC)
+        }
+        
         let scannerViewController = BarcodeScannerViewController()
         
         let navigationController = UINavigationController(rootViewController: scannerViewController)
@@ -70,7 +76,7 @@ public class SwiftBarcodeScanPlugin: NSObject, FlutterPlugin, BarcodeScannerView
         result?(FlutterError(code: errorCode, message: nil, details: nil))
     }
     
-    private class func topViewController(base: UIViewController? = UIApplication.shared.keyWindow?.rootViewController) -> UIViewController? {
+    private func topViewController(base: UIViewController?) -> UIViewController? {
         if let nav = base as? UINavigationController {
             return topViewController(base: nav.visibleViewController)
 


### PR DESCRIPTION
…, present Scan ViewController failed!

After flutter plugin register, the Top ViewController may changed .so when call public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult),It will used the old Top ViewController, but the it  is not in the window hierarchy. So fix it by when showBarcodeView(config: Configuration? = nil), get the topViewController.