### PR TITLE
 Changed protobuf_version and compileSdkVersion to support android12 …

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ version '1.0-SNAPSHOT'
 
 buildscript {
     ext.kotlin_version = '1.3.61'
-    ext.protobuf_version = '0.8.8'
+    ext.protobuf_version = '0.8.18'
     ext.protocVersion = '3.11.0'
     ext.javaliteVersion = '3.11.0'
     repositories {
@@ -30,7 +30,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'com.google.protobuf'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
…/ SDK32.

Changed protobuf_version and compileSdkVersion to support android12 / SDK32.
When building to android12, an error occurs and it cannot be started.

こんにちは。monoさん。
android12にビルドした場合、protobuf_versionの影響でビルドができないため修正してみました。
正直Androidのネイティブへの理解が低いため、適切でない可能性があります。間違っていたらすみません。