### PR TITLE
Migrate from JCenter to Maven Central for gradle dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     ext.javaliteVersion = '3.11.0'
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -21,7 +21,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
JCenter has issued a deprecation notice (https://blog.gradle.org/jcenter-shutdown). It is recommended to move to Maven Central, which Flutter itself is also officially doing. 

This PR addresses bug #56 by removing JCenter and adding Maven Central for gradle dependency resolution.