### PR TITLE
zxing version 1.9.13 does not exist in the mavenCentral

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -68,7 +68,7 @@ protobuf {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'me.dm7.barcodescanner:zxing:1.9.13'
+    implementation 'me.dm7.barcodescanner:zxing:1.9.8'
     implementation "com.google.protobuf:protobuf-javalite:$javaliteVersion"
     api 'com.google.android.material:material:1.1.0'
 }


### PR DESCRIPTION
Change 1.9.13 to since 1.9.8 does not exist in the mavenCentral
https://mvnrepository.com/artifact/me.dm7.barcodescanner/zxing

`
Execution failed for task ':app:checkReleaseDuplicateClasses'.
> Could not resolve all files for configuration ':app:releaseRuntimeClasspath'.
   > Could not find me.dm7.barcodescanner:zxing:1.9.13.
     Searched in the following locations:
       - https://dl.google.com/dl/android/maven2/me/dm7/barcodescanner/zxing/1.9.13/zxing-1.9.13.pom
       - https://repo.maven.apache.org/maven2/me/dm7/barcodescanner/zxing/1.9.13/zxing-1.9.13.pom
       - https://storage.googleapis.com/download.flutter.io/me/dm7/barcodescanner/zxing/1.9.13/zxing-1.9.13.pom
     Required by:
         project :app > project :barcode_scan2

`